### PR TITLE
Support for double tap zoom

### DIFF
--- a/sample/src/main/java/moe/tlaster/zoomable/sample/MainActivity.kt
+++ b/sample/src/main/java/moe/tlaster/zoomable/sample/MainActivity.kt
@@ -40,7 +40,14 @@ private fun Sample() {
         Box {
             Zoomable(
                 state = state,
-                enable = enable
+                enable = enable,
+                doubleTapScale = {
+                    if (state.scale > 32f) {
+                        state.minScale
+                    } else {
+                        state.scale * 2
+                    }
+                }
             ) {
                 // Our page content
                 Text(

--- a/zoomable/src/main/java/moe/tlaster/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/moe/tlaster/zoomable/Zoomable.kt
@@ -3,7 +3,6 @@
 package moe.tlaster.zoomable
 
 import androidx.compose.foundation.gestures.*
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -86,6 +85,22 @@ fun Zoomable(
                                 }
                             }
                         },
+                    )
+                }
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onDoubleTap = {
+                            if (enable) {
+                                val newScale = if (state.scale > state.minScale) {
+                                    state.minScale
+                                } else {
+                                    state.minScale * 2
+                                }
+                                scope.launch {
+                                    state.animateScaleTo(newScale)
+                                }
+                            }
+                        }
                     )
                 }
                 .transformable(state = transformableState)

--- a/zoomable/src/main/java/moe/tlaster/zoomable/Zoomable.kt
+++ b/zoomable/src/main/java/moe/tlaster/zoomable/Zoomable.kt
@@ -53,7 +53,9 @@ fun Zoomable(
         }
         val transformableState = rememberTransformableState { zoomChange, _, _ ->
             if (enable) {
-                state.onZoomChange(zoomChange)
+                scope.launch {
+                    state.onZoomChange(zoomChange)
+                }
             }
         }
         Box(

--- a/zoomable/src/main/java/moe/tlaster/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/moe/tlaster/zoomable/ZoomableState.kt
@@ -63,7 +63,7 @@ class ZoomableState(
     private var _scale by mutableStateOf(initialScale)
 
     init {
-        require(minScale < maxScale) { "minScale must be > maxScale" }
+        require(minScale < maxScale) { "minScale must be < maxScale" }
     }
 
     /**

--- a/zoomable/src/main/java/moe/tlaster/zoomable/ZoomableState.kt
+++ b/zoomable/src/main/java/moe/tlaster/zoomable/ZoomableState.kt
@@ -2,15 +2,14 @@ package moe.tlaster.zoomable
 
 import androidx.annotation.FloatRange
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.animation.core.exponentialDecay
+import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.util.VelocityTracker
 import kotlinx.coroutines.coroutineScope
@@ -58,9 +57,9 @@ class ZoomableState(
     @FloatRange(from = 0.0) initialScale: Float = minScale,
 ) {
     private val velocityTracker = VelocityTracker()
-    private var _translateY = Animatable(initialTranslateY)
-    private var _translateX = Animatable(initialTranslateX)
-    private var _scale by mutableStateOf(initialScale)
+    private val _translateY = Animatable(initialTranslateY)
+    private val _translateX = Animatable(initialTranslateX)
+    private val _scale = Animatable(initialScale)
 
     init {
         require(minScale < maxScale) { "minScale must be < maxScale" }
@@ -70,11 +69,8 @@ class ZoomableState(
      * The current scale value for [Zoomable]
      */
     @get:FloatRange(from = 0.0)
-    var scale: Float
-        get() = _scale
-        internal set(value) {
-            _scale = value.coerceIn(minimumValue = minScale, maximumValue = maxScale)
-        }
+    val scale: Float
+        get() = _scale.value
 
     /**
      * The current translateY value for [Zoomable]
@@ -92,6 +88,28 @@ class ZoomableState(
 
     internal val zooming: Boolean
         get() = scale > minScale && scale < maxScale
+
+    /**
+     * Instantly sets scale of [Zoomable] to given [scale]
+     */
+    suspend fun snapScaleTo(scale: Float) = coroutineScope {
+        _scale.snapTo(scale.coerceIn(minimumValue = minScale, maximumValue = maxScale))
+    }
+
+    /**
+     * Animates scale of [Zoomable] to given [scale]
+     */
+    suspend fun animateScaleTo(
+        scale: Float,
+        animationSpec: AnimationSpec<Float> = spring(),
+        initialVelocity: Float = 0f,
+    ) = coroutineScope {
+        _scale.animateTo(
+            targetValue = scale.coerceIn(minimumValue = minScale, maximumValue = maxScale),
+            animationSpec = animationSpec,
+            initialVelocity = initialVelocity,
+        )
+    }
 
     private suspend fun fling(velocity: Offset) = coroutineScope {
         launch {
@@ -127,9 +145,7 @@ class ZoomableState(
         _translateX.updateBounds(-maxX, maxX)
     }
 
-    internal fun onZoomChange(zoomChange: Float) {
-        scale *= zoomChange
-    }
+    internal suspend fun onZoomChange(zoomChange: Float) = snapScaleTo(scale * zoomChange)
 
     internal fun addPosition(timeMillis: Long, position: Offset) {
         velocityTracker.addPosition(timeMillis = timeMillis, position = position)


### PR DESCRIPTION
I added support for zooming in/out upon double tap.
It's pretty common for zoomable views to zoom to some predefined value (zoom back to initial state if already zoomed) upon double tap.
For that, `_scale` was made `Animatable`, similarly to `translation`.
I also introduced two public functions `snapScaleTo` and `animateScaleTo` - those might be useful for some [-] [+] buttons style ui outside of Zoomable widget.
